### PR TITLE
initialize queue with capacity size

### DIFF
--- a/libpool/getwork/EthGetworkClient.h
+++ b/libpool/getwork/EthGetworkClient.h
@@ -54,7 +54,7 @@ class EthGetworkClient : public PoolClient {
 
     std::atomic<bool> m_connecting = {false}; // Whether or not socket is on first try connect
     std::atomic<bool> m_txPending = {false};  // Whether or not an async socket operation is pending
-    boost::lockfree::queue<std::string*, boost::lockfree::capacity<8>> m_txQueue;
+    boost::lockfree::queue<std::string*> m_txQueue(8);
 
     boost::asio::io_service::strand m_io_strand;
 

--- a/libpool/getwork/EthGetworkClient.h
+++ b/libpool/getwork/EthGetworkClient.h
@@ -54,7 +54,7 @@ class EthGetworkClient : public PoolClient {
 
     std::atomic<bool> m_connecting = {false}; // Whether or not socket is on first try connect
     std::atomic<bool> m_txPending = {false};  // Whether or not an async socket operation is pending
-    boost::lockfree::queue<std::string*> m_txQueue;
+    boost::lockfree::queue<std::string*, boost::lockfree::capacity<8>> m_txQueue;
 
     boost::asio::io_service::strand m_io_strand;
 

--- a/libpool/getwork/EthGetworkClient.h
+++ b/libpool/getwork/EthGetworkClient.h
@@ -54,7 +54,7 @@ class EthGetworkClient : public PoolClient {
 
     std::atomic<bool> m_connecting = {false}; // Whether or not socket is on first try connect
     std::atomic<bool> m_txPending = {false};  // Whether or not an async socket operation is pending
-    boost::lockfree::queue<std::string*> m_txQueue(8);
+    boost::lockfree::queue<std::string*> m_txQueue{8};
 
     boost::asio::io_service::strand m_io_strand;
 


### PR DESCRIPTION
Fixes error when using the eth_getwork client.

boost::lockfree::queue<T, Options>::queue() [with T = std::__cxx11::basic_string<char>*; Options = {}]: Assertion `has_capacity' failed.